### PR TITLE
add hash of name of decompiler to sources jars

### DIFF
--- a/gradle-plugin/src/main/java/com/anatawa12/modPatching/source/internal/SourcePatchImpl.kt
+++ b/gradle-plugin/src/main/java/com/anatawa12/modPatching/source/internal/SourcePatchImpl.kt
@@ -29,7 +29,7 @@ class SourcePatchImpl(
     val decompileTaskName by lazy { mod.getTaskName("decompile") }
 
     @FrozenByFreeze(of = "mod")
-    val sourcesJarPath by lazy { getMcpJarPath("deobf-${extension.forgeFlowerVersion}-sources") }
+    val sourcesJarPath by lazy { getMcpJarPath("deobf-${extension.decompilerIdentifier}-sources") }
     val srcDirPath by lazy { RelativePathFromProjectRoot.of("src/main/$sourceTreeName") }
     val patchDirPath by lazy { RelativePathFromProjectRoot.of("src/main/$sourceTreeName-patches") }
 

--- a/gradle-plugin/src/main/java/com/anatawa12/modPatching/source/internal/SourcePatchingExtension.kt
+++ b/gradle-plugin/src/main/java/com/anatawa12/modPatching/source/internal/SourcePatchingExtension.kt
@@ -8,6 +8,7 @@ import com.anatawa12.modPatching.source.internal.SourceConstants.DECOMPILER_CONF
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectCollection
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.*
 
 class SourcePatchingExtension(private val project: Project) :
     SourcePatchContainer,
@@ -36,6 +37,23 @@ class SourcePatchingExtension(private val project: Project) :
     override var autoInstallCli: Boolean = false
     val mappingChannel get() = mappingName.substringBefore('_')
     val mappingVersion get() = mappingName.substringAfter('_')
+
+    internal val decompilerIdentifier: String
+        get() {
+            return if (dependencyAdded) {
+                forgeFlowerVersion
+            } else {
+                val configuration = project.configurations[DECOMPILER_CONFIGURATION]
+                val artifacts = configuration.incoming.artifacts.iterator()
+
+                if (!artifacts.hasNext()) error("please configure $DECOMPILER_CONFIGURATION before this line.")
+                val artifact = artifacts.next()
+                if (artifacts.hasNext()) error("please do not configure two or more dependencies for $DECOMPILER_CONFIGURATION.")
+
+                val id = artifact.id.displayName.hashCode().toString(16).padStart(32 / 4, '0')
+                "resolved-decompiler-$id"
+            }
+        }
 
     override fun patch(mod: DownloadingMod, block: Action<ModPatch>): ModPatch {
         require(mod is AbstractDownloadingMod) { "unsupported DownloadingMod: $mod" }


### PR DESCRIPTION
Fixes #115

Previously, the mod-patching will the same name of source files for any decompilers if we use `modPatchingDecompiler` configuration.
This files this problem by adding the hash of the name of decompiler to source files.